### PR TITLE
Fix adjacent jsx elements in shop page

### DIFF
--- a/client/src/pages/ShopPage.jsx
+++ b/client/src/pages/ShopPage.jsx
@@ -7,24 +7,26 @@ export default function ShopPage() {
   const [active, setActive] = useState(categories[0]?.id || '');
   const filtered = useMemo(() => products.filter(p => !active || p.categoryId === active), [active]);
   return (
-    <div className="grid md:grid-cols-[1fr_320px] gap-6">
-      <div>
-        <div className="flex gap-2 flex-wrap mb-4">
-          {categories.map(c => (
-            <button key={c.id} onClick={() => setActive(c.id)} className={`px-4 py-2 rounded-full border ${active === c.id ? 'bg-amber-700 text-white border-amber-700' : 'bg-white text-amber-900 border-amber-300 hover:bg-amber-50'}`}>{c.name}</button>
-          ))}
+    <>
+      <div className="grid md:grid-cols-[1fr_320px] gap-6">
+        <div>
+          <div className="flex gap-2 flex-wrap mb-4">
+            {categories.map(c => (
+              <button key={c.id} onClick={() => setActive(c.id)} className={`px-4 py-2 rounded-full border ${active === c.id ? 'bg-amber-700 text-white border-amber-700' : 'bg-white text-amber-900 border-amber-300 hover:bg-amber-50'}`}>{c.name}</button>
+            ))}
+          </div>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {filtered.map(p => (
+              <ProductCard key={p.id} product={p} />
+            ))}
+          </div>
         </div>
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filtered.map(p => (
-            <ProductCard key={p.id} product={p} />
-          ))}
-        </div>
+        <aside>
+          <CartPanel />
+        </aside>
       </div>
-      <aside>
-        <CartPanel />
-      </aside>
-    </div>
-    <Footer />
+      <Footer />
+    </>
   );
 }
 


### PR DESCRIPTION
Wrap adjacent JSX elements in `ShopPage.jsx` with a React fragment to resolve a JSX parsing error.

The previous JSX structure in `ShopPage.jsx` returned two top-level elements (`<div>` and `<Footer />`) directly, which caused a "Adjacent JSX elements must be wrapped in an enclosing tag" error. Wrapping them in a fragment provides a single parent element, satisfying React's requirement.

---
<a href="https://cursor.com/background-agent?bcId=bc-048f807a-98ca-4eae-92e4-e97d9f7a696f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-048f807a-98ca-4eae-92e4-e97d9f7a696f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

